### PR TITLE
chore: enable sourcemaps for `radix-vue` package

### DIFF
--- a/packages/radix-vue/vite.config.ts
+++ b/packages/radix-vue/vite.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
     },
   },
   build: {
+    sourcemap: true,
     lib: {
       name: 'radix-vue',
       fileName: 'index',


### PR DESCRIPTION
Enable sourcemaps for `radix-vue` so it's easier to understand and debug possible usage issues in development.

After running locally `pnpm --filter radix-vue build` I see that `*.js.map` files are generated in dist. I don't have much experience with publishing to `npm` but I guess these files should be picked up automatically on publish.