### PR TITLE
docs(animation): update link to motion one

### DIFF
--- a/docs/content/guides/animation.md
+++ b/docs/content/guides/animation.md
@@ -94,7 +94,7 @@ import { DialogClose, DialogContent, DialogDescription, DialogOverlay, DialogPor
 Futhemore, we discovered that [Oku Motion](https://motion.oku-ui.com/), a motion library powered by Motion One and based on the Web Animations API, works perfectly with Radix Vue.
 
 
-Check out this [Stackblitz Demo](https://stackblitz.com/edit/hfxgtx-n6jbjp?file=src%2FApp.vue) 🤩
+Check out this [Stackblitz Demo](https://stackblitz.com/edit/hfxgtx-plux4s?file=src%2FApp.vue) 🤩
 :::
 
 

--- a/docs/content/guides/animation.md
+++ b/docs/content/guides/animation.md
@@ -91,7 +91,7 @@ import { DialogClose, DialogContent, DialogDescription, DialogOverlay, DialogPor
 ``` 
 
 ::: tip
-Futhemore, we discovered that [Motion One](https://motion.dev/vue/quick-start), a Web Animations API based animation library works perfectly with Radix Vue.
+Futhemore, we discovered that [Oku Motion](https://motion.oku-ui.com/), a motion library powered by Motion One and based on the Web Animations API, works perfectly with Radix Vue.
 
 
 Check out this [Stackblitz Demo](https://stackblitz.com/edit/hfxgtx-n6jbjp?file=src%2FApp.vue) 🤩


### PR DESCRIPTION
In the [animation](https://www.radix-vue.com/guides/animation.html) page, we link to a deprecated version of Motion One for Vue. The new implementation is [Oku Motion](https://motion.oku-ui.com/) and is still based on Motion One.

This PR fixes the link and refactors the related paragraph. I am not sure how to update the Stackblitz demo, but the only changes needed are:

1. Switch the packages:

```bash
npm remove motion
npm install @oku-ui/motion --save
```

2. replace `motion/vue` with `@oku-ui/motion` in `App.vue`