### PR TITLE
build: improve support for code splitting, ditch umd, sourcemaps

### DIFF
--- a/packages/radix-vue/package.json
+++ b/packages/radix-vue/package.json
@@ -82,7 +82,9 @@
   ],
   "scripts": {
     "build": "pnpm type-check && pnpm build-only",
-    "build-only": "vite build",
+    "build-only": "pnpm run build-only-esm && pnpm run build-only-cjs",
+    "build-only-esm": "vite build",
+    "build-only-cjs": "vite build --config vite.config.cjs.ts",
     "watch": "vite build --watch",
     "type-check": "vue-tsc -p tsconfig.check.json --noEmit",
     "type-gen": "vue-tsc --declaration  --emitDeclarationOnly",

--- a/packages/radix-vue/package.json
+++ b/packages/radix-vue/package.json
@@ -29,7 +29,7 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "require": "./dist/index.umd.cjs"
+      "require": "./dist/index.cjs"
     },
     "./date": {
       "import": {
@@ -38,7 +38,7 @@
       },
       "require": {
         "types": "./dist/date/index.d.ts",
-        "default": "./dist/date.umd.cjs"
+        "default": "./dist/date.cjs"
       }
     },
     "./namespaced": {
@@ -72,7 +72,7 @@
       }
     }
   },
-  "main": "./dist/index.umd.cjs",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "typings": "./dist/index.d.ts",

--- a/packages/radix-vue/vite.config.cjs.ts
+++ b/packages/radix-vue/vite.config.cjs.ts
@@ -1,0 +1,24 @@
+import { defineConfig, mergeConfig } from 'vite'
+import viteConfig from './vite.config'
+
+const merged = defineConfig(mergeConfig(viteConfig, defineConfig({
+  build: {
+    emptyOutDir: false, // Contains esm build
+    target: 'es2022', // Transpile syntax to Node 18+
+    sourcemap: false,
+    minify: true,
+    rollupOptions: {
+      output: {
+        // No code splitting
+        manualChunks: {},
+      },
+    },
+  },
+})))
+
+// We need to *replace* these, however mergeConfig won't let us do that (it wants to merge the arrays).
+merged.plugins = merged.plugins.slice(0, -1) // Don't run DTS
+if (merged.build.lib)
+  merged.build.lib.formats = ['cjs']
+
+export default merged

--- a/packages/radix-vue/vite.config.ts
+++ b/packages/radix-vue/vite.config.ts
@@ -1,4 +1,4 @@
-import { relative, resolve } from 'node:path'
+import { resolve } from 'node:path'
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import vueJsx from '@vitejs/plugin-vue-jsx'
@@ -33,7 +33,7 @@ export default defineConfig({
     sourcemap: true,
     lib: {
       name: 'radix-vue',
-      formats: ['es', 'cjs'],
+      formats: ['es'],
       entry: {
         index: resolve(__dirname, 'src/index.ts'),
         date: resolve(__dirname, 'src/date/index.ts'),
@@ -46,8 +46,28 @@ export default defineConfig({
         ...Object.keys(pkg.peerDependencies ?? {}),
       ],
       output: {
+        // The package is split in chunks to make lazy-loading possible.
+        // No major bundler supports splitting files, even if the file itself is side effects free.
+        //
+        // Each namespace (Accordion, AlertDialog, ...) is bundled as individual chunks re-exported by index.js.
+        // This allows namespace-level granularity which is enough for all realistic code-splitting scenarios.
+        //
+        // The only exception are components intended for root-level usage, which are bundled in their own chunk.
+        // This allows setting up a component's provider while still lazy-loading the actual component.
         manualChunks: (moduleId) => {
-          return relative(projectRootDir, moduleId).split('/')[1]
+          const [namespace, file] = moduleId.split('?')[0].split('/').slice(-2)
+
+          // Entrypoint
+          if (namespace === 'src')
+            return file
+
+          // Providers
+          const ROOT_LEVEL_COMPONENTS = ['ToastProvider.vue', 'TooltipProvider.vue']
+          if (ROOT_LEVEL_COMPONENTS.includes(file))
+            return 'RootProviders'
+
+          // Namespace
+          return namespace
         },
         assetFileNames: (chunkInfo) => {
           if (chunkInfo.name === 'style.css')


### PR DESCRIPTION
This PR improves code splitting support by keeping each component namespace within its own chunk, allowing Rollup to move parts of the library in lazy-loaded chunks instead of entirely hoisted in the entry file. While this is the main motivation of this PR, I also tried a few things with the config that I think are worth sharing:

- The UMD bundle has been removed in favor of a CJS build; I don't think the UMD config was correctly configured for it to function as expected. (Mentioned in the Discord server)
- TypeScript declaration files are now passed through Rollup to be a single file; this significantly reduces the package size (-1.6M) at the expense of slightly less pretty declaration files.
- Target has been set to esnext, which pretty much disables processing of recent ES features. That's quite an opinionated change; the assumption I'm making is that the package will likely be re-bundled so not processing is the best for this scenario. This may not be the case for CJS builds, though.
- This PR also attempts to give back a look at #469. Enabling source-maps adds ~1.4M to the bundle per format, for a combined 2.8M increase in package size (from 1.8M to 4.6M). That's unfortunately more than double, especially knowing that most of it is duplicate `sourcesContent` in esm and cjs maps.

The PR is a draft at this time with my experiments; as they might cause breaking and what not I'm not sure if it fits for v1 or if it may directly go to v2. Most points are also up for discussion and will need an opinion from the maintainers in favor or against as they affect package quality, target and size.

For the reference: current package size is 3.2M. Measures taken by running `pnpm build-only` in `packages/radix-vue` and running `du -sh dist`.
