### PR TITLE
fix(NavigationMenu): prevent content from hiding when disableHoverTri…

### DIFF
--- a/packages/radix-vue/src/NavigationMenu/NavigationMenuRoot.vue
+++ b/packages/radix-vue/src/NavigationMenu/NavigationMenuRoot.vue
@@ -166,6 +166,9 @@ provideNavigationMenuContext({
     debouncedFn()
   },
   onContentLeave: () => {
+    if (disableHoverTrigger.value) {
+      return
+    }
     debouncedFn('')
   },
   onItemSelect: (val) => {


### PR DESCRIPTION
Fixes https://github.com/radix-vue/radix-vue/issues/1315.

When `disableHoverTrigger=true` is set, the `trigger` respects this setting and doesn't hide the content. However, there is no check in `onContentLeave`, causing the content to be hidden incorrectly.

But I believe this modification has a minor issue—it makes the logic inconsistent with how `onTriggerLeave` is handled.