### PR TITLE
fix(Tooltip): use trigger's `ownerDocument` to track `pointermove`

### DIFF
--- a/packages/radix-vue/src/shared/useGraceArea.ts
+++ b/packages/radix-vue/src/shared/useGraceArea.ts
@@ -59,9 +59,9 @@ export function useGraceArea(triggerElement: Ref<HTMLElement | undefined>, conta
           pointerExit.trigger()
         }
       }
-      document.addEventListener('pointermove', handleTrackPointerGrace)
+      triggerElement.value?.ownerDocument.addEventListener('pointermove', handleTrackPointerGrace)
 
-      cleanupFn(() => document.removeEventListener('pointermove', handleTrackPointerGrace))
+      cleanupFn(() => triggerElement.value?.ownerDocument.removeEventListener('pointermove', handleTrackPointerGrace))
     }
   })
 


### PR DESCRIPTION
In Popup windows, the tooltip content wasn't closing after moving from the area, only after going back to the original window and moving the pointer there.

https://github.com/user-attachments/assets/45f94c06-1b27-469c-9b95-b21d7fd9075a

