### PR TITLE
fix: fix invalid duration class name

### DIFF
--- a/.histoire/tailwind.config.js
+++ b/.histoire/tailwind.config.js
@@ -156,6 +156,9 @@ export default {
         slideIn: 'slideIn 150ms cubic-bezier(0.16, 1, 0.3, 1)',
         swipeOut: 'swipeOut 100ms ease-out',
       },
+      transitionDuration: {
+        250: '250ms',
+      },
     },
   },
   plugins: [

--- a/packages/core/src/NavigationMenu/story/NavigationMenuAlignment.story.vue
+++ b/packages/core/src/NavigationMenu/story/NavigationMenuAlignment.story.vue
@@ -37,7 +37,7 @@ const currentTrigger = ref('')
                 Learn
                 <Icon
                   icon="radix-icons:caret-down"
-                  class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
+                  class="text-green10 relative top-[1px] transition-transform duration-250 ease-in group-data-[state=open]:-rotate-180"
                 />
               </NavigationMenuTrigger>
               <NavigationMenuContent
@@ -89,7 +89,7 @@ const currentTrigger = ref('')
                 Overview 2
                 <Icon
                   icon="radix-icons:caret-down"
-                  class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
+                  class="text-green10 relative top-[1px] transition-transform duration-250 ease-in group-data-[state=open]:-rotate-180"
                 />
               </NavigationMenuTrigger>
               <NavigationMenuContent
@@ -128,7 +128,7 @@ const currentTrigger = ref('')
                 Overview
                 <Icon
                   icon="radix-icons:caret-down"
-                  class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
+                  class="text-green10 relative top-[1px] transition-transform duration-250 ease-in group-data-[state=open]:-rotate-180"
                 />
               </NavigationMenuTrigger>
               <NavigationMenuContent

--- a/packages/core/src/NavigationMenu/story/NavigationMenuBasic.story.vue
+++ b/packages/core/src/NavigationMenu/story/NavigationMenuBasic.story.vue
@@ -39,7 +39,7 @@ const state = reactive({
                 Products
                 <Icon
                   icon="radix-icons:caret-down"
-                  class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
+                  class="text-green10 relative top-[1px] transition-transform duration-250 ease-in group-data-[state=open]:-rotate-180"
                 />
               </NavigationMenuTrigger>
 
@@ -66,7 +66,7 @@ const state = reactive({
                 Company
                 <Icon
                   icon="radix-icons:caret-down"
-                  class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
+                  class="text-green10 relative top-[1px] transition-transform duration-250 ease-in group-data-[state=open]:-rotate-180"
                 />
               </NavigationMenuTrigger>
               <NavigationMenuContent
@@ -89,7 +89,7 @@ const state = reactive({
                 Developers
                 <Icon
                   icon="radix-icons:caret-down"
-                  class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
+                  class="text-green10 relative top-[1px] transition-transform duration-250 ease-in group-data-[state=open]:-rotate-180"
                 />
               </NavigationMenuTrigger>
               <NavigationMenuContent

--- a/packages/core/src/NavigationMenu/story/NavigationMenuDemo.story.vue
+++ b/packages/core/src/NavigationMenu/story/NavigationMenuDemo.story.vue
@@ -37,7 +37,7 @@ const currentTrigger = ref('')
                 Learn
                 <Icon
                   icon="radix-icons:caret-down"
-                  class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
+                  class="text-green10 relative top-[1px] transition-transform duration-250 ease-in group-data-[state=open]:-rotate-180"
                 />
               </NavigationMenuTrigger>
               <NavigationMenuContent
@@ -108,7 +108,7 @@ const currentTrigger = ref('')
                 Overview
                 <Icon
                   icon="radix-icons:caret-down"
-                  class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
+                  class="text-green10 relative top-[1px] transition-transform duration-250 ease-in group-data-[state=open]:-rotate-180"
                 />
               </NavigationMenuTrigger>
               <NavigationMenuContent

--- a/packages/core/src/NavigationMenu/story/NavigationMenuSubmenus.story.vue
+++ b/packages/core/src/NavigationMenu/story/NavigationMenuSubmenus.story.vue
@@ -36,7 +36,7 @@ const currentTrigger = ref('')
                 Products
                 <Icon
                   icon="radix-icons:caret-down"
-                  class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
+                  class="text-green10 relative top-[1px] transition-transform duration-250 ease-in group-data-[state=open]:-rotate-180"
                 />
               </NavigationMenuTrigger>
 
@@ -57,7 +57,7 @@ const currentTrigger = ref('')
                         Extensibility
                         <Icon
                           icon="radix-icons:caret-down"
-                          class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
+                          class="text-green10 relative top-[1px] transition-transform duration-250 ease-in group-data-[state=open]:-rotate-180"
                         />
                       </NavigationMenuTrigger>
 
@@ -84,7 +84,7 @@ const currentTrigger = ref('')
                         Security
                         <Icon
                           icon="radix-icons:caret-down"
-                          class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
+                          class="text-green10 relative top-[1px] transition-transform duration-250 ease-in group-data-[state=open]:-rotate-180"
                         />
                       </NavigationMenuTrigger>
                       <NavigationMenuContent
@@ -107,7 +107,7 @@ const currentTrigger = ref('')
                         Authentication
                         <Icon
                           icon="radix-icons:caret-down"
-                          class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
+                          class="text-green10 relative top-[1px] transition-transform duration-250 ease-in group-data-[state=open]:-rotate-180"
                         />
                       </NavigationMenuTrigger>
                       <NavigationMenuContent
@@ -140,7 +140,7 @@ const currentTrigger = ref('')
                 Company
                 <Icon
                   icon="radix-icons:caret-down"
-                  class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
+                  class="text-green10 relative top-[1px] transition-transform duration-250 ease-in group-data-[state=open]:-rotate-180"
                 />
               </NavigationMenuTrigger>
               <NavigationMenuContent
@@ -162,7 +162,7 @@ const currentTrigger = ref('')
                         Customers
                         <Icon
                           icon="radix-icons:caret-down"
-                          class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
+                          class="text-green10 relative top-[1px] transition-transform duration-250 ease-in group-data-[state=open]:-rotate-180"
                         />
                       </NavigationMenuTrigger>
 
@@ -189,7 +189,7 @@ const currentTrigger = ref('')
                         Security
                         <Icon
                           icon="radix-icons:caret-down"
-                          class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
+                          class="text-green10 relative top-[1px] transition-transform duration-250 ease-in group-data-[state=open]:-rotate-180"
                         />
                       </NavigationMenuTrigger>
                       <NavigationMenuContent
@@ -212,7 +212,7 @@ const currentTrigger = ref('')
                         Authentication
                         <Icon
                           icon="radix-icons:caret-down"
-                          class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
+                          class="text-green10 relative top-[1px] transition-transform duration-250 ease-in group-data-[state=open]:-rotate-180"
                         />
                       </NavigationMenuTrigger>
                       <NavigationMenuContent

--- a/packages/core/src/NavigationMenu/story/NavigationMenuViewport.story.vue
+++ b/packages/core/src/NavigationMenu/story/NavigationMenuViewport.story.vue
@@ -35,7 +35,7 @@ const currentTrigger = ref('')
                 Products
                 <Icon
                   icon="radix-icons:caret-down"
-                  class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
+                  class="text-green10 relative top-[1px] transition-transform duration-250 ease-in group-data-[state=open]:-rotate-180"
                 />
               </NavigationMenuTrigger>
 
@@ -62,7 +62,7 @@ const currentTrigger = ref('')
                 Company
                 <Icon
                   icon="radix-icons:caret-down"
-                  class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
+                  class="text-green10 relative top-[1px] transition-transform duration-250 ease-in group-data-[state=open]:-rotate-180"
                 />
               </NavigationMenuTrigger>
               <NavigationMenuContent
@@ -85,7 +85,7 @@ const currentTrigger = ref('')
                 Developers
                 <Icon
                   icon="radix-icons:caret-down"
-                  class="text-green10 relative top-[1px] transition-transform duration-[250ms] ease-in group-data-[state=open]:-rotate-180"
+                  class="text-green10 relative top-[1px] transition-transform duration-250 ease-in group-data-[state=open]:-rotate-180"
                 />
               </NavigationMenuTrigger>
               <NavigationMenuContent

--- a/packages/core/src/Popper/PopperContent.vue
+++ b/packages/core/src/Popper/PopperContent.vue
@@ -288,7 +288,7 @@ const computedMiddleware = computedEager(() => {
   ] as Middleware[]
 })
 
-// If provided custom reference, it will overwrite the defautl anchor element
+// If provided custom reference, it will overwrite the default anchor element
 const reference = computed(() => props.reference ?? rootContext.anchor.value)
 
 const { floatingStyles, placement, isPositioned, middlewareData, update } = useFloating(


### PR DESCRIPTION
When I run `dev:story`, I notice there's a warning that says:

```
The class `duration-[250ms]` is ambiguous and matches multiple utilities.
```

According to https://github.com/jamiebuilds/tailwindcss-animate/pull/46, right now we can't use  arbitrary values for `duration`.