### PR TITLE
fix: fix path to constant build entry

### DIFF
--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -35,7 +35,7 @@ export default defineConfig({
       entry: {
         index: resolve(__dirname, 'src/index.ts'),
         date: resolve(__dirname, 'src/date/index.ts'),
-        constant: resolve(__dirname, '/constant/index.ts'),
+        constant: resolve(__dirname, 'constant/index.ts'),
       },
     },
     rollupOptions: {


### PR DESCRIPTION
The presence of `/` prefix in the constant build entry breaks the build. It works fine when removed :)