### PR TITLE
Update styles.css for Calendar - color

### DIFF
--- a/docs/components/demo/Calendar/css/styles.css
+++ b/docs/components/demo/Calendar/css/styles.css
@@ -40,7 +40,6 @@
 .CalendarHeading {
   font-weight: 500;
   color: #000000;
-  color: 15px;
 }
 
 .CalendarWrapper {


### PR DESCRIPTION
The color is already defined the line before & it shouldn't have the unit "px".