### PR TITLE
docs: update component demo styling and typo

### DIFF
--- a/docs/components/demo/Calendar/css/styles.css
+++ b/docs/components/demo/Calendar/css/styles.css
@@ -117,7 +117,7 @@
 }
 
 .CalendarCellTrigger[data-disabled] {
-  cursor: none;
+  cursor: not-allowed;
   color: rgba(0,0,0,0.3);
 }
 


### PR DESCRIPTION
Using "none" as cursor value is invalid