### PR TITLE
Update index.vue for CalendarSelect - Locale Case

### DIFF
--- a/docs/components/demo/CalendarSelect/css/index.vue
+++ b/docs/components/demo/CalendarSelect/css/index.vue
@@ -8,7 +8,7 @@ const preferences = [
   { locale: 'en-US', label: 'Default', ordering: 'gregory' },
   { label: 'Arabic (Algeria)', locale: 'ar-DZ', territories: 'DJ DZ EH ER IQ JO KM LB LY MA MR OM PS SD SY TD TN YE', ordering: 'gregory islamic islamic-civil islamic-tbla' },
   { label: 'Arabic (United Arab Emirates)', locale: 'ar-AE', territories: 'AE BH KW QA', ordering: 'gregory islamic-umalqura islamic islamic-civil islamic-tbla' },
-  { label: 'Arabic (Egypt)', locale: 'AR-EG', territories: 'EG', ordering: 'gregory coptic islamic islamic-civil islamic-tbla' },
+  { label: 'Arabic (Egypt)', locale: 'ar-EG', territories: 'EG', ordering: 'gregory coptic islamic islamic-civil islamic-tbla' },
   { label: 'Arabic (Saudi Arabia)', locale: 'ar-SA', territories: 'SA', ordering: 'islamic-umalqura gregory islamic islamic-rgsa' },
   { label: 'Farsi (Afghanistan)', locale: 'fa-AF', territories: 'AF IR', ordering: 'persian gregory islamic islamic-civil islamic-tbla' },
   { label: 'Amharic (Ethiopia)', locale: 'am-ET', territories: 'ET', ordering: 'gregory ethiopic ethioaa' },


### PR DESCRIPTION
In the preferences array, you have locale: 'AR-EG' for Arabic (Egypt). This should be locale: 'ar-EG' to maintain consistent casing (usually lowercase for language codes).