### PR TITLE
Update styles.css for ContextMenu

### DIFF
--- a/docs/components/demo/ContextMenu/css/styles.css
+++ b/docs/components/demo/ContextMenu/css/styles.css
@@ -50,7 +50,7 @@
 .ContextMenuRadioItem[data-disabled],
 .ContextMenuSubTrigger[data-disabled] {
   color: var(--mauve-8);
-  pointer-events: 'none';
+  pointer-events: none;
 }
 .ContextMenuItem[data-highlighted],
 .ContextMenuCheckboxItem[data-highlighted],


### PR DESCRIPTION
In the selector .ContextMenuItem[data-disabled], the pointer-events property should not have quotes around none