### PR TITLE
fix(combobox/item): fix some items not add into allItems map

### DIFF
--- a/packages/core/src/Combobox/ComboboxItem.vue
+++ b/packages/core/src/Combobox/ComboboxItem.vue
@@ -44,10 +44,20 @@ if (!props.value) {
 }
 
 const isRender = computed(() => {
-  if (rootContext.isVirtual.value || rootContext.ignoreFilter.value || !rootContext.filterState.search)
+  if (rootContext.isVirtual.value || rootContext.ignoreFilter.value || !rootContext.filterState.search) {
     return true
-  else
-    return rootContext.filterState.filtered.items.get(id)! > 0
+  }
+  else {
+    const filteredCurrentItem = rootContext.filterState.filtered.items.get(id)
+    // If the filtered items is undefined means not in the all times map yet
+    // Do the first render to add into the map
+    if (filteredCurrentItem === undefined) {
+      return true
+    }
+
+    // Check with filter
+    return filteredCurrentItem > 0
+  }
 })
 
 onMounted(() => {

--- a/packages/core/src/Combobox/ComboboxRoot.vue
+++ b/packages/core/src/Combobox/ComboboxRoot.vue
@@ -60,7 +60,7 @@ export interface ComboboxRootProps<T = AcceptableValue> extends Omit<ListboxRoot
 <script setup lang="ts" generic="T extends AcceptableValue = AcceptableValue">
 import { computed, nextTick, reactive, ref, toRefs, watch } from 'vue'
 import { PopperRoot } from '@/Popper'
-import { type EventHookOn, createEventHook, useVModel, watchDebounced } from '@vueuse/core'
+import { type EventHookOn, createEventHook, useVModel } from '@vueuse/core'
 import { ListboxRoot } from '@/Listbox'
 
 const props = withDefaults(defineProps<ComboboxRootProps<T>>(), {
@@ -181,9 +181,9 @@ watch(() => open.value, () => {
   })
 }, { flush: 'post' })
 
-watchDebounced(() => allItems.value.size, (val) => {
+watch(() => allItems.value.size, (val) => {
   filterItems()
-}, { debounce: 10 })
+})
 
 defineExpose({
   highlightedElement,

--- a/packages/core/src/Combobox/ComboboxRoot.vue
+++ b/packages/core/src/Combobox/ComboboxRoot.vue
@@ -169,7 +169,7 @@ function filterItems() {
   filterState.filtered.count = itemCount
 }
 
-watch(() => filterState.search, () => {
+watch([() => filterState.search, () => allItems.value.size], () => {
   filterItems()
 }, { immediate: true })
 
@@ -180,10 +180,6 @@ watch(() => open.value, () => {
       filterItems()
   })
 }, { flush: 'post' })
-
-watch(() => allItems.value.size, (val) => {
-  filterItems()
-})
 
 defineExpose({
   highlightedElement,

--- a/packages/core/src/Combobox/ComboboxRoot.vue
+++ b/packages/core/src/Combobox/ComboboxRoot.vue
@@ -60,7 +60,7 @@ export interface ComboboxRootProps<T = AcceptableValue> extends Omit<ListboxRoot
 <script setup lang="ts" generic="T extends AcceptableValue = AcceptableValue">
 import { computed, nextTick, reactive, ref, toRefs, watch } from 'vue'
 import { PopperRoot } from '@/Popper'
-import { type EventHookOn, createEventHook, useVModel } from '@vueuse/core'
+import { type EventHookOn, createEventHook, useVModel, watchDebounced } from '@vueuse/core'
 import { ListboxRoot } from '@/Listbox'
 
 const props = withDefaults(defineProps<ComboboxRootProps<T>>(), {
@@ -180,6 +180,10 @@ watch(() => open.value, () => {
       filterItems()
   })
 }, { flush: 'post' })
+
+watchDebounced(() => allItems.value.size, (val) => {
+  filterItems()
+}, { debounce: 10 })
 
 defineExpose({
   highlightedElement,


### PR DESCRIPTION
### Description

closes #1234

This pr fixes when `rootContext.isVirtual.value || rootContext.ignoreFilter.value || !rootContext.filterState.search` is false, the item will never add into `allItems` map.

To reproduce this bug, create a async combobox (e.g. the one in the story), before opening the dropdown, give any value to search query.

<hr />

Added an event listener to apply filter when `allItems` size changes.

\* It uses `watch` rather than `watchDebounced` even the items are set one by one because it's handled by [vue `watch`](https://vuejs.org/guide/essentials/watchers.html#callback-flush-timing)
