### PR TITLE
fix(docs): typo in Stepper component

### DIFF
--- a/docs/content/components/stepper.md
+++ b/docs/content/components/stepper.md
@@ -146,7 +146,7 @@ If you want to hide the description, wrap it inside our Visually Hidden utility 
 
 ### Vertical
 
-You can create vertical tabs by using the `orientation` prop.
+You can create vertical steps by using the `orientation` prop.
 
 ```vue line=8
 <script setup>

--- a/packages/radix-vue/src/Stepper/StepperItem.vue
+++ b/packages/radix-vue/src/Stepper/StepperItem.vue
@@ -22,7 +22,7 @@ export interface StepperItemContext {
 export interface StepperItemProps extends PrimitiveProps {
   /** A unique value that associates the stepper item with an index */
   step: number
-  /** When `true`, prevents the user from interacting with the tab. */
+  /** When `true`, prevents the user from interacting with the step. */
   disabled?: boolean
   /** Shows whether the step is completed. */
   completed?: boolean

--- a/packages/radix-vue/src/Stepper/StepperRoot.vue
+++ b/packages/radix-vue/src/Stepper/StepperRoot.vue
@@ -17,12 +17,12 @@ export interface StepperRootContext {
 
 export interface StepperRootProps extends PrimitiveProps {
   /**
-   * The value of the tab that should be active when initially rendered. Use when you do not need to control the state of the tabs
+   * The value of the step that should be active when initially rendered. Use when you do not need to control the state of the steps.
    */
   defaultValue?: number
   /**
-   * The orientation the tabs are laid out.
-   * Mainly so arrow navigation is done accordingly (left & right vs. up & down)
+   * The orientation the steps are laid out.
+   * Mainly so arrow navigation is done accordingly (left & right vs. up & down).
    * @defaultValue horizontal
    */
   orientation?: DataOrientation
@@ -30,9 +30,9 @@ export interface StepperRootProps extends PrimitiveProps {
    * The reading direction of the combobox when applicable. <br> If omitted, inherits globally from `ConfigProvider` or assumes LTR (left-to-right) reading mode.
    */
   dir?: Direction
-  /** The controlled value of the tab to activate. Can be bound as `v-model`. */
+  /** The controlled value of the step to activate. Can be bound as `v-model`. */
   modelValue?: number
-  /** Whether or not the steps must be completed in order */
+  /** Whether or not the steps must be completed in order. */
   linear?: boolean
 }
 export type StepperRootEmits = {


### PR DESCRIPTION
Not sure if it was intended, but the term 'tab' is used instead of 'step' in the Stepper component.