### PR TITLE
fix(Listbox): handle currentElement not in dom on focusout

### DIFF
--- a/packages/radix-vue/src/Listbox/ListboxRoot.vue
+++ b/packages/radix-vue/src/Listbox/ListboxRoot.vue
@@ -334,7 +334,7 @@ provideListboxRootContext({
     @focusout="async (event: FocusEvent) => {
       const target = (event.relatedTarget || event.target) as HTMLElement | null
       await nextTick()
-      if (highlightedElement && !currentElement.contains(target)) {
+      if (highlightedElement && currentElement && !currentElement.contains(target)) {
         onLeave(event)
       }
     }"


### PR DESCRIPTION
Because nextTick is added in #1331, if the listbox component gets removed from the dom, an error occurs.

Link to repro: https://stackblitz.com/edit/7jpwyi-yem3zd?file=src%2FApp.vue - checkout the logs in the console