### PR TITLE
fix: dev on Windows not show preview component codes

### DIFF
--- a/docs/.vitepress/plugins/ComponentPreview.ts
+++ b/docs/.vitepress/plugins/ComponentPreview.ts
@@ -49,6 +49,8 @@ export default function (md: MarkdownRenderer) {
       const { realPath, path: _path } = state.env as MarkdownEnv
 
       const childFiles = readdirSync(resolve(dirname(realPath ?? _path), pathName), { withFileTypes: false, recursive: true })
+        .map(file => typeof file === 'string' ? file.split(/[/\\]/).join('/') : file)
+
       const groupedFiles = childFiles.reduce((prev, curr) => {
         if (typeof curr !== 'string')
           return prev


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/632500f0-fb6d-407c-8807-81756a43bbeb)
After:
![image](https://github.com/user-attachments/assets/84bf2967-5f27-4fec-a814-c66329820d81)
