### PR TITLE
Add onTagRemove emit in TagsInputRoot.vue

### DIFF
--- a/packages/radix-vue/src/TagsInput/TagsInputRoot.vue
+++ b/packages/radix-vue/src/TagsInput/TagsInputRoot.vue
@@ -43,6 +43,8 @@ export type TagsInputRootEmits<T = AcceptableInputValue> = {
   'update:modelValue': [payload: Array<T>]
   /** Event handler called when the value is invalid */
   'invalid': [payload: T]
+  /** Event handler called when tag is removed */
+  'onTagRemove': [payload: T]
 }
 
 export interface TagsInputRootContext<T = AcceptableInputValue> {
@@ -160,6 +162,7 @@ provideTagsInputRootContext({
           const index = collection.findIndex(i => i === selectedElement.value)
           modelValue.value.splice(index, 1)
           selectedElement.value = selectedElement.value === lastTag ? collection.at(index - 1) : collection.at(index + 1)
+          emits('onTagRemove', selectedElement.value)
           event.preventDefault()
         }
         else if (event.key === 'Backspace') {


### PR DESCRIPTION
It’s currently challenging to trigger an action when an element is removed. At the moment, we’re watching modelValue, and when the new array is shorter than the previous one, we identify the missing element and use it as a payload to update our database.

To streamline this, I propose adding an onTagRemove event that emits the removed element as a payload. This will allow us to directly handle the tag removal in our database, making the process more efficient and reliable.

Let me know if you have any questions. Thank you.