### PR TITLE
fix(Dialog): iOS safari scroll lock not working (#1423)

### DIFF
--- a/packages/radix-vue/src/shared/useBodyScrollLock.ts
+++ b/packages/radix-vue/src/shared/useBodyScrollLock.ts
@@ -31,6 +31,7 @@ const useBodyLockStackCount = createSharedComposable(() => {
     document.body.style.paddingRight = ''
     document.body.style.marginRight = ''
     document.body.style.pointerEvents = ''
+    document.body.style.touchAction = ''
     document.body.style.removeProperty('--scrollbar-width')
     document.body.style.overflow = initialOverflow.value ?? ''
     isIOS && stopTouchMoveListener?.()
@@ -90,6 +91,7 @@ const useBodyLockStackCount = createSharedComposable(() => {
     nextTick(() => {
       document.body.style.pointerEvents = 'none'
       document.body.style.overflow = 'hidden'
+      document.body.style.touchAction = 'none'
     })
   }, { immediate: true, flush: 'sync' })
 


### PR DESCRIPTION
fixes #1423

By adding `touch-action: none`, Safari seems to stop misbehaving. 
There might be some more edgecases hiding elsewhere as you can't ever be to sure with Safari, but this should do. 
At least for now 🙂 