### PR TITLE
fix(Toast): negative duration

### DIFF
--- a/packages/radix-vue/src/Toast/ToastRootImpl.vue
+++ b/packages/radix-vue/src/Toast/ToastRootImpl.vue
@@ -66,7 +66,11 @@ const { forwardRef, currentElement } = useForwardExpose()
 const providerContext = injectToastProviderContext()
 const pointerStartRef = ref<{ x: number, y: number } | null>(null)
 const swipeDeltaRef = ref<{ x: number, y: number } | null>(null)
-const duration = computed(() => props.duration || providerContext.duration.value)
+const duration = computed(
+  () => typeof props.duration === 'number'
+    ? props.duration
+    : providerContext.duration.value,
+)
 
 const closeTimerStartTimeRef = ref(0)
 const closeTimerRemainingTimeRef = ref(duration.value)

--- a/packages/radix-vue/src/Toast/ToastRootImpl.vue
+++ b/packages/radix-vue/src/Toast/ToastRootImpl.vue
@@ -79,7 +79,7 @@ const remainingRaf = useRafFn(() => {
 }, { fpsLimit: 60 })
 
 function startTimer(duration: number) {
-  if (!duration || duration === Number.POSITIVE_INFINITY)
+  if (duration <= 0 || duration === Number.POSITIVE_INFINITY)
     return
   // startTimer is used inside a watch with immediate set to true.
   // This results in code execution during SSR.


### PR DESCRIPTION
This is a follow-up from https://github.com/nuxt/ui/issues/2665

Currently the Toast's duration only starts the timer if false or infinite.

But having a negative duration should also trigger a Toast without a timer.