### PR TITLE
chore: improve build

### DIFF
--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -3,8 +3,12 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import vueJsx from '@vitejs/plugin-vue-jsx'
 import dts from 'vite-plugin-dts'
+import pkg from './package.json'
 
 const projectRootDir = resolve(__dirname)
+
+// A bit of a hack, but lets us use the proper extension in chunk filenames
+let currentFormat = ''
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -28,11 +32,13 @@ export default defineConfig({
     ],
   },
   build: {
-    minify: true,
+    minify: false,
     target: 'esnext',
+    sourcemap: true,
     lib: {
       name: 'reka-ui',
       fileName: (format, name) => {
+        currentFormat = format
         return `${name}.${format === 'es' ? 'js' : 'cjs'}`
       },
       entry: {
@@ -42,12 +48,27 @@ export default defineConfig({
       },
     },
     rollupOptions: {
-      // make sure to externalize deps that shouldn't be bundled
-      // into your library (Vue)
-      external: ['vue', '@floating-ui/vue', '@internationalized/date', '@internationalized/number'],
+      external: [
+        'nanoid/non-secure',
+        ...Object.keys(pkg.dependencies ?? {}),
+        ...Object.keys(pkg.peerDependencies ?? {}),
+      ],
       output: {
-        preserveModules: true,
+        // Don't rely on preserveModules
+        // It creates a lot of unwanted files because of the multiple sections of SFC files
+        manualChunks: (moduleId, meta) => {
+          const info = meta.getModuleInfo(moduleId)
+          if (!info.isIncluded) {
+            // Don't create empty chunks
+            return null
+          }
+
+          const [namespace, file] = moduleId.split('?')[0].split('/').slice(-2)
+          return `${namespace}/${file.slice(0, file.lastIndexOf('.'))}`
+        },
+
         exports: 'named',
+        chunkFileNames: chunk => `${chunk.name}.${currentFormat === 'es' ? 'js' : 'cjs'}`,
         assetFileNames: (chunkInfo) => {
           if (chunkInfo.name === 'style.css')
             return 'index.css'


### PR DESCRIPTION
This PR supersedes and closes #1102 

It does not use the same approach as proposed in #1102 however; seeing the current v2 build uses `preserveModules`. However, because of how the SFC gets split in multiple virtual chunks this causes a lot of unwanted files to clutter the build making it larger than it needs to be.

The approach proposed in this PR mitigates it by using manualChunks to achieve the intended result of a 1:1 mapping between Vue files and the resulting JS files. A little hack has been introduced as well to properly name chunk files with the right file extension and without a hash.

Minification has been disabled: along with the drop of hashes the intent is to make eventual [dependency patches](https://pnpm.io/cli/patch) less brittle (see last comment of #908 for a use-case). This is also yet-another-attempt at building with sourcemaps enabled 😄

Package size measurements: measured by running `pnpm run build-only; du -sh dist` in `packages/core`.
- Current v2: 7.4M
- This PR (no maps): 4.8M
- This PR (w/ maps): 11M
- [#1102](https://github.com/unovue/radix-vue/pull/1102) chunking approach[^1] (no maps): 2.5M
- [#1102](https://github.com/unovue/radix-vue/pull/1102) chunking approach (w/ maps): 5.8M

[^1]: these numbers were obtained by replacing the manual chunking approach from this PR by the manual chunking approach used in #1102. Does not include the more heavy-handed dual config approach for esm and cjs.