### PR TITLE
chore: fix grammar in `Fragment` props JSDoc comment

### DIFF
--- a/packages/radix-vue/src/Primitive/Primitive.ts
+++ b/packages/radix-vue/src/Primitive/Primitive.ts
@@ -29,7 +29,7 @@ export interface PrimitiveProps {
    */
   asChild?: boolean
   /**
-   * The element or component this component should render as. Can be overwrite by `asChild`
+   * The element or component this component should render as. Can be overwritten by `asChild`.
    * @defaultValue "div"
    */
   as?: AsTag | Component

--- a/packages/radix-vue/src/Primitive/Slot.ts
+++ b/packages/radix-vue/src/Primitive/Slot.ts
@@ -16,13 +16,13 @@ export const Slot = defineComponent({
 
       const firstNonCommentChildren = childrens[firstNonCommentChildrenIndex]
 
-      // remove props ref from being inferred
+      // Remove props ref from being inferred
       delete firstNonCommentChildren.props?.ref
 
       const mergedProps = firstNonCommentChildren.props
         ? mergeProps(attrs, firstNonCommentChildren.props)
         : attrs
-      // remove class to prevent duplicated
+      // Remove class to prevent duplicated
       if (attrs.class && firstNonCommentChildren.props?.class)
         delete firstNonCommentChildren.props.class
       const cloned = cloneVNode(firstNonCommentChildren, mergedProps)


### PR DESCRIPTION
Hi there!

Thanks for this great library. As I scrolled through the documentation, I kept seeing this tiny spelling error, since the `Fragment` props are inherited by almost all components.

Is this PR of substance? No. This PR pales in comparison to your amazing work. Nevertheless, I just wanted to contribute this little grammar fix.