### PR TITLE
Introducing Radix Vue Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Radix is an unstyled, customisable UI Library with built in accessibility for bu
 <a href="https://www.npmjs.com/package/radix-vue" target="__blank"><img src="https://img.shields.io/npm/v/radix-vue?style=flat&colorA=002438&colorB=41c399" alt="NPM version"></a>
 <a href="https://www.npmjs.com/package/radix-vue" target="__blank"><img alt="NPM Downloads" src="https://img.shields.io/npm/dm/radix-vue?flat&colorA=002438&colorB=41c399"></a>
 <a href="https://github.com/unovue/radix-vue" target="__blank"><img alt="GitHub stars" src="https://img.shields.io/github/stars/unovue/radix-vue?flat&colorA=002438&colorB=41c399"></a>
+<a href="https://gurubase.io/g/radix-vue" target="__blank"><img alt="Gurubase" src="https://img.shields.io/badge/Gurubase-Ask%20Radix%20Vue%20Guru-006BFF"></a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Radix is an unstyled, customisable UI Library with built in accessibility for bu
 <a href="https://www.npmjs.com/package/radix-vue" target="__blank"><img src="https://img.shields.io/npm/v/radix-vue?style=flat&colorA=002438&colorB=41c399" alt="NPM version"></a>
 <a href="https://www.npmjs.com/package/radix-vue" target="__blank"><img alt="NPM Downloads" src="https://img.shields.io/npm/dm/radix-vue?flat&colorA=002438&colorB=41c399"></a>
 <a href="https://github.com/unovue/radix-vue" target="__blank"><img alt="GitHub stars" src="https://img.shields.io/github/stars/unovue/radix-vue?flat&colorA=002438&colorB=41c399"></a>
-<a href="https://gurubase.io/g/radix-vue" target="__blank"><img alt="Gurubase" src="https://img.shields.io/badge/Gurubase-Ask%20Radix%20Vue%20Guru-006BFF"></a>
+<a href="https://gurubase.io/g/radix-vue" target="__blank"><img alt="Gurubase" src="https://img.shields.io/badge/Gurubase-Ask%20Radix%20Vue%20Guru-002438?style=flat&colorA=002438&colorB=41c399"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Radix Vue Guru](https://gurubase.io/g/radix-vue) to Gurubase. Radix Vue Guru uses the data from this repo and data from the [docs](https://radix-vue.com) to answer questions by leveraging the LLM.

In this PR, I showcased the "Radix Vue Guru", which highlights that Radix Vue now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Radix Vue Guru in Gurubase, just let me know that's totally fine.
