### PR TITLE
fix(Combobox): Pass `highlightOnHover` to Listbox

### DIFF
--- a/packages/core/src/Combobox/ComboboxRoot.vue
+++ b/packages/core/src/Combobox/ComboboxRoot.vue
@@ -225,6 +225,7 @@ provideComboboxRootContext({
       :name="name"
       :required="required"
       :disabled="disabled"
+      :highlight-on-hover="props.highlightOnHover"
       @highlight="emits('highlight', $event as any)"
     >
       <slot


### PR DESCRIPTION
In v2, the new prop Combobox prop `highlightOnHover` is now passed to ListboxRoot.

`ComboboxRootProps` inherits of `highlightOnHover` prop from `ListboxRootProps`, so it must be passed explicitly.