### PR TITLE
fix(Menu): Pass `positionStrategy` prop to PopperContent

### DIFF
--- a/packages/core/src/Menu/MenuContentImpl.vue
+++ b/packages/core/src/Menu/MenuContentImpl.vue
@@ -315,6 +315,7 @@ provideMenuContentContext({
           :collision-padding="collisionPadding"
           :arrow-padding="arrowPadding"
           :prioritize-position="prioritizePosition"
+          :position-strategy="positionStrategy"
           :sticky="sticky"
           :hide-when-detached="hideWhenDetached"
           @keydown="handleKeyDown"


### PR DESCRIPTION
In v2, the new PopperContent `positionStrategy` prop is not forwarded in MenuContent.