### PR TITLE
fix(DateField): Fixed segement initialization in DateField parser util to not include…

### DIFF
--- a/packages/radix-vue/src/DateField/utils/parser.ts
+++ b/packages/radix-vue/src/DateField/utils/parser.ts
@@ -40,6 +40,10 @@ export function initializeSegmentValues(granularity: Granularity): SegmentValueO
   }).filter(([key]) => {
     if (key === 'literal' || key === null)
       return false
+    if (granularity === 'minute' && key === 'second')
+      return false
+    if (granularity === 'hour' && (key === 'second' || key === 'minute'))
+      return false
     if (granularity === 'day')
       return !calendarDateTimeGranularities.includes(key) && key !== 'dayPeriod'
     else return true


### PR DESCRIPTION
Noticed a bug when using DateField, or other components that leverage DateField such as DatePicker where the modelValue wouldn't update appropriately when fully entered if granularity is set to `minute` or `hour`. 

When setting granularity to `minute` for instance, the DateField's parser util still includes `second` as a segment when using `initializeSegmentValues`. This prevents `handleSegmentKeydown` from ever setting the modelValue since there's always at least one null value.

Happy to adjust this change based on any feedback.