### PR TITLE
fix(ComboboxItem): revert `props.value` check

### DIFF
--- a/packages/core/src/Combobox/ComboboxItem.vue
+++ b/packages/core/src/Combobox/ComboboxItem.vue
@@ -37,7 +37,7 @@ const groupContext = injectComboboxGroupContext(null)
 
 const { primitiveElement, currentElement } = usePrimitiveElement()
 
-if (!props.value) {
+if (props.value === '') {
   throw new Error(
     'A <ComboboxItem /> must have a value prop that is not an empty string. This is because the Combobox value can be set to an empty string to clear the selection and show the placeholder.',
   )


### PR DESCRIPTION
Reverting this as it was on `main` branch: https://github.com/unovue/radix-vue/blob/main/packages/radix-vue/src/Combobox/ComboboxItem.vue#L94 because I encountered an issue when passing an array of booleans in items and binding this to the `ComboboxItem` value prop.