### PR TITLE
Update ARIA broken link dialog.md

### DIFF
--- a/docs/content/components/dialog.md
+++ b/docs/content/components/dialog.md
@@ -285,7 +285,7 @@ For example, if you have some global Toaster component that should not close the
 
 ## Accessibility
 
-Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal).
+Adheres to the [Dialog WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/).
 
 ### Close icon button
 


### PR DESCRIPTION
current link is broken and gives a 404 error. new or updated link has a dash, think they also have a redirect without a dash but needs the forward slash at the end for it to work.