### PR TITLE
fix: useBodyScrollLock type error

### DIFF
--- a/packages/radix-vue/src/shared/useBodyScrollLock.ts
+++ b/packages/radix-vue/src/shared/useBodyScrollLock.ts
@@ -131,10 +131,10 @@ function checkOverflowScroll(ele: Element): boolean {
 function preventDefault(rawEvent: TouchEvent): boolean {
   const e = rawEvent || window.event
 
-  const _target = e.target as Element
+  const _target = e.target
 
   // Do not prevent if element or parentNodes have overflow: scroll set.
-  if (checkOverflowScroll(_target))
+  if (_target instanceof Element && checkOverflowScroll(_target))
     return false
 
   // Do not prevent if the event has more than one touch (usually meaning this is a multi touch gesture like pinch to zoom).


### PR DESCRIPTION
Fixes type error of useBodyScrollLock introduced in https://github.com/unovue/radix-vue/pull/1428.

`TypeError: Argument 1 ('element') to Window.getComputedStyle must be an instance of Element`.

Apparently, not every target of touchmove event has to be Element. Also good example of why type casting should be avoided.