### PR TITLE
fix: remove use of `cssText` in focus-guards

### DIFF
--- a/packages/radix-vue/src/shared/useFocusGuards.ts
+++ b/packages/radix-vue/src/shared/useFocusGuards.ts
@@ -38,7 +38,9 @@ function createFocusGuard() {
   const element = document.createElement('span')
   element.setAttribute('data-radix-focus-guard', '')
   element.tabIndex = 0
-  element.style.cssText
-    = 'outline: none; opacity: 0; position: fixed; pointer-events: none'
+  element.style.outline = 'none'
+  element.style.opacity = '0'
+  element.style.position = 'fixed'
+  element.style.pointerEvents = 'none'
   return element
 }


### PR DESCRIPTION
Violates Content-Security-Policy unless `style-src: 'unsafe-inline'` is permitted otherwise. (from radix-ui)