### PR TITLE
build: replace `fast-deep-equal` with `dequal`

### DIFF
--- a/packages/radix-vue/package.json
+++ b/packages/radix-vue/package.json
@@ -93,16 +93,16 @@
     "vue": ">= 3.2.0"
   },
   "dependencies": {
-    "@floating-ui/dom": "^1.6.7",
-    "@floating-ui/vue": "^1.1.0",
-    "@internationalized/date": "^3.5.4",
-    "@internationalized/number": "^3.5.3",
-    "@tanstack/vue-virtual": "^3.8.1",
+    "@floating-ui/dom": "^1.6.12",
+    "@floating-ui/vue": "^1.1.5",
+    "@internationalized/date": "^3.6.0",
+    "@internationalized/number": "^3.6.0",
+    "@tanstack/vue-virtual": "^3.10.9",
     "@vueuse/core": "^10.11.0",
     "@vueuse/shared": "^10.11.0",
     "aria-hidden": "^1.2.4",
     "defu": "^6.1.4",
-    "fast-deep-equal": "^3.1.3",
+    "dequal": "^2.0.3",
     "nanoid": "^5.0.7"
   },
   "devDependencies": {

--- a/packages/radix-vue/src/Combobox/ComboboxItem.vue
+++ b/packages/radix-vue/src/Combobox/ComboboxItem.vue
@@ -40,7 +40,7 @@ import {
   Primitive,
 } from '@/Primitive'
 import { CollectionItem } from '@/Collection'
-import isEqual from 'fast-deep-equal'
+import { dequal } from 'dequal'
 
 const props = defineProps<ComboboxItemProps<T>>()
 const emits = defineEmits<ComboboxItemEmits<T>>()
@@ -53,18 +53,18 @@ const { forwardRef } = useForwardExpose()
 
 const isSelected = computed(() =>
   rootContext.multiple.value && Array.isArray(rootContext.modelValue.value)
-    ? rootContext.modelValue.value?.some(val => isEqual(val, props.value))
-    : isEqual(rootContext.modelValue?.value, props.value),
+    ? rootContext.modelValue.value?.some(val => dequal(val, props.value))
+    : dequal(rootContext.modelValue?.value, props.value),
 )
 
-const isFocused = computed(() => isEqual(rootContext.selectedValue.value, props.value))
+const isFocused = computed(() => dequal(rootContext.selectedValue.value, props.value))
 const textId = useId(undefined, 'radix-vue-combobox-item')
 const optionId = useId(undefined, 'radix-vue-combobox-option')
 
 const isInOption = computed(() =>
   rootContext.isUserInputted.value
     ? rootContext.searchTerm.value === ''
-    || !!rootContext.filteredOptions.value.find(i => isEqual(i, props.value))
+    || !!rootContext.filteredOptions.value.find(i => dequal(i, props.value))
     : true)
 
 async function handleSelect(ev: SelectEvent<T>) {

--- a/packages/radix-vue/src/Combobox/ComboboxRoot.vue
+++ b/packages/radix-vue/src/Combobox/ComboboxRoot.vue
@@ -86,7 +86,7 @@ import { PopperRoot } from '@/Popper'
 import { Primitive } from '@/Primitive'
 import { useVModel } from '@vueuse/core'
 import { VisuallyHiddenInput } from '@/VisuallyHidden'
-import isEqual from 'fast-deep-equal'
+import { dequal } from 'dequal'
 
 const props = withDefaults(defineProps<ComboboxRootProps<T>>(), {
   open: undefined,
@@ -154,7 +154,7 @@ async function onOpenChange(val: boolean) {
 
 function onValueChange(val: T) {
   if (Array.isArray(modelValue.value) && multiple.value) {
-    const index = modelValue.value.findIndex(i => isEqual(i, val))
+    const index = modelValue.value.findIndex(i => dequal(i, val))
     const modelArray = [...modelValue.value]
     index === -1 ? modelArray.push(val) : modelArray.splice(index, 1)
     modelValue.value = modelArray
@@ -208,9 +208,9 @@ function resetSearchTerm() {
   }
 }
 
-const activeIndex = computed(() => filteredOptions.value.findIndex(i => isEqual(i, selectedValue.value)))
+const activeIndex = computed(() => filteredOptions.value.findIndex(i => dequal(i, selectedValue.value)))
 const selectedElement = computed(() => {
-  return reactiveItems.value.find(i => isEqual(i.value, selectedValue.value))?.ref
+  return reactiveItems.value.find(i => dequal(i.value, selectedValue.value))?.ref
 })
 
 const stringifiedModelValue = computed(() => JSON.stringify(modelValue.value))

--- a/packages/radix-vue/src/Listbox/ListboxVirtualizer.vue
+++ b/packages/radix-vue/src/Listbox/ListboxVirtualizer.vue
@@ -28,7 +28,7 @@ defineSlots<{
   default: (props: {
     option: T
     virtualizer: Virtualizer<Element | Window, Element>
-    virtualItem: VirtualItem<Element>
+    virtualItem: VirtualItem
   }) => any
 }>()
 

--- a/packages/radix-vue/src/Listbox/utils.ts
+++ b/packages/radix-vue/src/Listbox/utils.ts
@@ -1,4 +1,4 @@
-import isEqual from 'fast-deep-equal'
+import { dequal } from 'dequal'
 
 export function queryCheckedElement(parentEl: HTMLElement | null) {
   return parentEl?.querySelector('[data-state=checked]') as HTMLElement | null
@@ -26,5 +26,5 @@ export function compare<T>(value?: T, currentValue?: T, comparator?: string | ((
   if (typeof comparator === 'string')
     return value?.[comparator as keyof T] === currentValue?.[comparator as keyof T]
 
-  return isEqual(value, currentValue)
+  return dequal(value, currentValue)
 }

--- a/packages/radix-vue/src/Tree/TreeVirtualizer.vue
+++ b/packages/radix-vue/src/Tree/TreeVirtualizer.vue
@@ -22,7 +22,7 @@ defineSlots<{
   default: (props: {
     item: FlattenedItem<Record<string, any>>
     virtualizer: Virtualizer<Element | Window, Element>
-    virtualItem: VirtualItem<Element>
+    virtualItem: VirtualItem
   }) => any
 }>()
 

--- a/packages/radix-vue/src/shared/arrays.ts
+++ b/packages/radix-vue/src/shared/arrays.ts
@@ -1,4 +1,4 @@
-import isEqual from 'fast-deep-equal'
+import { dequal } from 'dequal'
 
 /**
  * The function `areEqual` compares two arrays and returns true if they are equal in length and have
@@ -55,8 +55,8 @@ export function chunk<T>(arr: T[], size: number): T[][] {
  * found in the input array, an empty array is returned.
  */
 export function findValuesBetween<T>(array: T[], start: T, end: T) {
-  const startIndex = array.findIndex(i => isEqual(i, start))
-  const endIndex = array.findIndex(i => isEqual(i, end))
+  const startIndex = array.findIndex(i => dequal(i, start))
+  const endIndex = array.findIndex(i => dequal(i, end))
   if (startIndex === -1 || endIndex === -1)
     return []
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ importers:
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^2.27.3
-        version: 2.27.3(@typescript-eslint/utils@8.5.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.3.3))(@vue/compiler-sfc@3.4.31)(eslint@9.10.0(jiti@1.21.6))(typescript@5.3.3)(vitest@2.1.1(@types/node@20.14.9))
+        version: 2.27.3(@typescript-eslint/utils@8.5.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.3.3))(@vue/compiler-sfc@3.4.31)(eslint@9.10.0(jiti@1.21.6))(typescript@5.3.3)(vitest@2.1.1(@types/node@20.14.9)(jsdom@25.0.1))
       '@commitlint/cli':
         specifier: ^19.3.0
         version: 19.3.0(@types/node@20.14.9)(typescript@5.3.3)
@@ -67,7 +67,7 @@ importers:
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^2.27.3
-        version: 2.27.3(@typescript-eslint/utils@8.5.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.4.2))(@vue/compiler-sfc@3.4.31)(eslint@9.10.0(jiti@1.21.6))(typescript@5.4.2)(vitest@2.1.1(@types/node@20.14.9))
+        version: 2.27.3(@typescript-eslint/utils@8.5.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.4.2))(@vue/compiler-sfc@3.4.31)(eslint@9.10.0(jiti@1.21.6))(typescript@5.4.2)(vitest@2.1.1(@types/node@20.14.9)(jsdom@25.0.1))
       '@floating-ui/dom':
         specifier: ^1.6.7
         version: 1.6.7
@@ -199,20 +199,20 @@ importers:
   packages/radix-vue:
     dependencies:
       '@floating-ui/dom':
-        specifier: ^1.6.7
-        version: 1.6.7
+        specifier: ^1.6.12
+        version: 1.6.12
       '@floating-ui/vue':
-        specifier: ^1.1.0
-        version: 1.1.0(vue@3.4.31(typescript@5.4.2))
+        specifier: ^1.1.5
+        version: 1.1.5(vue@3.4.31(typescript@5.4.2))
       '@internationalized/date':
-        specifier: ^3.5.4
-        version: 3.5.4
+        specifier: ^3.6.0
+        version: 3.6.0
       '@internationalized/number':
-        specifier: ^3.5.3
-        version: 3.5.3
+        specifier: ^3.6.0
+        version: 3.6.0
       '@tanstack/vue-virtual':
-        specifier: ^3.8.1
-        version: 3.8.1(vue@3.4.31(typescript@5.4.2))
+        specifier: ^3.10.9
+        version: 3.10.9(vue@3.4.31(typescript@5.4.2))
       '@vueuse/core':
         specifier: ^10.11.0
         version: 10.11.0(vue@3.4.31(typescript@5.4.2))
@@ -225,9 +225,9 @@ importers:
       defu:
         specifier: ^6.1.4
         version: 6.1.4
-      fast-deep-equal:
-        specifier: ^3.1.3
-        version: 3.1.3
+      dequal:
+        specifier: ^2.0.3
+        version: 2.0.3
       nanoid:
         specifier: ^5.0.7
         version: 5.0.7
@@ -1155,14 +1155,23 @@ packages:
   '@floating-ui/core@1.6.4':
     resolution: {integrity: sha512-a4IowK4QkXl4SCWTGUR0INAfEOX3wtsYw3rKK5InQEHMGObkR8Xk44qYQD9P4r6HHw0iIfK6GUKECmY8sTkqRA==}
 
+  '@floating-ui/dom@1.6.12':
+    resolution: {integrity: sha512-NP83c0HjokcGVEMeoStg317VD9W7eDlGK7457dMBANbKA6GJZdc7rjujdgqzTaz93jkGgc5P/jeWbaCHnMNc+w==}
+
   '@floating-ui/dom@1.6.7':
     resolution: {integrity: sha512-wmVfPG5o2xnKDU4jx/m4w5qva9FWHcnZ8BvzEe90D/RpwsJaTAVYPEPdQ8sbr/N8zZTAHlZUTQdqg8ZUbzHmng==}
 
   '@floating-ui/utils@0.2.4':
     resolution: {integrity: sha512-dWO2pw8hhi+WrXq1YJy2yCuWoL20PddgGaqTgVe4cOS9Q6qklXCiA1tJEqX6BEwRNSCP84/afac9hd4MS+zEUA==}
 
+  '@floating-ui/utils@0.2.8':
+    resolution: {integrity: sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==}
+
   '@floating-ui/vue@1.1.0':
     resolution: {integrity: sha512-+Qq6K0zYcGZ6JoJXiL0z2gHh+77GyGhwXJMDiRx23tbYHLbQokw8DSC+cGIecjW8z7j3aWtSDtZyB1pNw2QBPA==}
+
+  '@floating-ui/vue@1.1.5':
+    resolution: {integrity: sha512-ynL1p5Z+woPVSwgMGqeDrx6HrJfGIDzFyESFkyqJKilGW1+h/8yVY29Khn0LaU6wHBRwZ13ntG6reiHWK6jyzw==}
 
   '@histoire/app@0.17.17':
     resolution: {integrity: sha512-2i1V38o08V+eaR0d3L0/EA6AYG14xyQBJbyYv0Hz3r4sH3Elj1FoJiwolbCfTDmkOnSgwWTc7+JoCqkLIbxfhA==}
@@ -1203,8 +1212,11 @@ packages:
   '@internationalized/date@3.5.4':
     resolution: {integrity: sha512-qoVJVro+O0rBaw+8HPjUB1iH8Ihf8oziEnqMnvhJUSuVIrHOuZ6eNLHNvzXJKUvAtaDiqMnRlg8Z2mgh09BlUw==}
 
-  '@internationalized/number@3.5.3':
-    resolution: {integrity: sha512-rd1wA3ebzlp0Mehj5YTuTI50AQEx80gWFyHcQu+u91/5NgdwBecO8BH6ipPfE+lmQ9d63vpB3H9SHoIUiupllw==}
+  '@internationalized/date@3.6.0':
+    resolution: {integrity: sha512-+z6ti+CcJnRlLHok/emGEsWQhe7kfSmEW+/6qCzvKY67YPh7YOBfvc7+/+NXq+zJlbArg30tYpqLjNgcAYv2YQ==}
+
+  '@internationalized/number@3.6.0':
+    resolution: {integrity: sha512-PtrRcJVy7nw++wn4W2OuePQQfTqDzfusSuY1QTtui4wa7r+rGVtR75pO8CyKvHvzyQYi3Q1uO5sY0AsB4e65Bw==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -1582,11 +1594,11 @@ packages:
   '@swc/helpers@0.5.11':
     resolution: {integrity: sha512-YNlnKRWF2sVojTpIyzwou9XoTNbzbzONwRhOoniEioF1AtaitTvVZblaQRrAzChWQ1bLYyYSWzM18y4WwgzJ+A==}
 
-  '@tanstack/virtual-core@3.8.1':
-    resolution: {integrity: sha512-uNtAwenT276M9QYCjTBoHZ8X3MUeCRoGK59zPi92hMIxdfS9AyHjkDWJ94WroDxnv48UE+hIeo21BU84jKc8aQ==}
+  '@tanstack/virtual-core@3.10.9':
+    resolution: {integrity: sha512-kBknKOKzmeR7lN+vSadaKWXaLS0SZZG+oqpQ/k80Q6g9REn6zRHS/ZYdrIzHnpHgy/eWs00SujveUN/GJT2qTw==}
 
-  '@tanstack/vue-virtual@3.8.1':
-    resolution: {integrity: sha512-uhty1LzUbbcVc5zdMMSUjUt/ECTlMCtK49Ww7dH2m4lNNLGYwkj5SbfrAD8uCZxV1VeV7DRMXqhwUTELyR5rrA==}
+  '@tanstack/vue-virtual@3.10.9':
+    resolution: {integrity: sha512-KU2quiwJQpA0sdflpXw24bhW+x8PG+FlrSJK3Ilobim671HNn4ztLVWUCEz3Inei4dLYq+GW1MK9X6i6ZeirkQ==}
     peerDependencies:
       vue: ^2.7.0 || ^3.0.0
 
@@ -6345,7 +6357,7 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@antfu/eslint-config@2.27.3(@typescript-eslint/utils@8.5.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.3.3))(@vue/compiler-sfc@3.4.31)(eslint@9.10.0(jiti@1.21.6))(typescript@5.3.3)(vitest@2.1.1(@types/node@20.14.9))':
+  '@antfu/eslint-config@2.27.3(@typescript-eslint/utils@8.5.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.3.3))(@vue/compiler-sfc@3.4.31)(eslint@9.10.0(jiti@1.21.6))(typescript@5.3.3)(vitest@2.1.1(@types/node@20.14.9)(jsdom@25.0.1))':
     dependencies:
       '@antfu/install-pkg': 0.4.1
       '@clack/prompts': 0.7.0
@@ -6353,7 +6365,7 @@ snapshots:
       '@stylistic/eslint-plugin': 2.6.4(eslint@9.10.0(jiti@1.21.6))(typescript@5.3.3)
       '@typescript-eslint/eslint-plugin': 8.5.0(@typescript-eslint/parser@8.5.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.3.3))(eslint@9.10.0(jiti@1.21.6))(typescript@5.3.3)
       '@typescript-eslint/parser': 8.5.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.3.3)
-      '@vitest/eslint-plugin': 1.1.0(@typescript-eslint/utils@8.5.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.3.3))(eslint@9.10.0(jiti@1.21.6))(typescript@5.3.3)(vitest@2.1.1(@types/node@20.14.9))
+      '@vitest/eslint-plugin': 1.1.0(@typescript-eslint/utils@8.5.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.3.3))(eslint@9.10.0(jiti@1.21.6))(typescript@5.3.3)(vitest@2.1.1(@types/node@20.14.9)(jsdom@25.0.1))
       eslint: 9.10.0(jiti@1.21.6)
       eslint-config-flat-gitignore: 0.1.8
       eslint-flat-config-utils: 0.3.1
@@ -6391,15 +6403,15 @@ snapshots:
       - typescript
       - vitest
 
-  '@antfu/eslint-config@2.27.3(@typescript-eslint/utils@8.5.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.4.2))(@vue/compiler-sfc@3.4.31)(eslint@9.10.0(jiti@1.21.6))(typescript@5.4.2)(vitest@2.1.1(@types/node@20.14.9))':
+  '@antfu/eslint-config@2.27.3(@typescript-eslint/utils@8.5.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.4.2))(@vue/compiler-sfc@3.4.31)(eslint@9.10.0(jiti@1.21.6))(typescript@5.4.2)(vitest@2.1.1(@types/node@20.14.9)(jsdom@25.0.1))':
     dependencies:
       '@antfu/install-pkg': 0.4.1
       '@clack/prompts': 0.7.0
       '@eslint-community/eslint-plugin-eslint-comments': 4.4.0(eslint@9.10.0(jiti@1.21.6))
       '@stylistic/eslint-plugin': 2.6.4(eslint@9.10.0(jiti@1.21.6))(typescript@5.4.2)
-      '@typescript-eslint/eslint-plugin': 8.5.0(@typescript-eslint/parser@8.5.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.4.2))(eslint@9.10.0(jiti@1.21.6))(typescript@5.4.2)
+      '@typescript-eslint/eslint-plugin': 8.5.0(@typescript-eslint/parser@8.5.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.3.3))(eslint@9.10.0(jiti@1.21.6))(typescript@5.4.2)
       '@typescript-eslint/parser': 8.5.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.4.2)
-      '@vitest/eslint-plugin': 1.1.0(@typescript-eslint/utils@8.5.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.4.2))(eslint@9.10.0(jiti@1.21.6))(typescript@5.4.2)(vitest@2.1.1(@types/node@20.14.9))
+      '@vitest/eslint-plugin': 1.1.0(@typescript-eslint/utils@8.5.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.4.2))(eslint@9.10.0(jiti@1.21.6))(typescript@5.4.2)(vitest@2.1.1(@types/node@20.14.9)(jsdom@25.0.1))
       eslint: 9.10.0(jiti@1.21.6)
       eslint-config-flat-gitignore: 0.1.8
       eslint-flat-config-utils: 0.3.1
@@ -6416,7 +6428,7 @@ snapshots:
       eslint-plugin-regexp: 2.6.0(eslint@9.10.0(jiti@1.21.6))
       eslint-plugin-toml: 0.11.1(eslint@9.10.0(jiti@1.21.6))
       eslint-plugin-unicorn: 55.0.0(eslint@9.10.0(jiti@1.21.6))
-      eslint-plugin-unused-imports: 4.1.3(@typescript-eslint/eslint-plugin@8.5.0(@typescript-eslint/parser@8.5.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.4.2))(eslint@9.10.0(jiti@1.21.6))(typescript@5.4.2))(eslint@9.10.0(jiti@1.21.6))
+      eslint-plugin-unused-imports: 4.1.3(@typescript-eslint/eslint-plugin@8.5.0(@typescript-eslint/parser@8.5.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.3.3))(eslint@9.10.0(jiti@1.21.6))(typescript@5.3.3))(eslint@9.10.0(jiti@1.21.6))
       eslint-plugin-vue: 9.27.0(eslint@9.10.0(jiti@1.21.6))
       eslint-plugin-yml: 1.14.0(eslint@9.10.0(jiti@1.21.6))
       eslint-processor-vue-blocks: 0.1.2(@vue/compiler-sfc@3.4.31)(eslint@9.10.0(jiti@1.21.6))
@@ -7109,6 +7121,11 @@ snapshots:
     dependencies:
       '@floating-ui/utils': 0.2.4
 
+  '@floating-ui/dom@1.6.12':
+    dependencies:
+      '@floating-ui/core': 1.6.4
+      '@floating-ui/utils': 0.2.8
+
   '@floating-ui/dom@1.6.7':
     dependencies:
       '@floating-ui/core': 1.6.4
@@ -7116,10 +7133,21 @@ snapshots:
 
   '@floating-ui/utils@0.2.4': {}
 
+  '@floating-ui/utils@0.2.8': {}
+
   '@floating-ui/vue@1.1.0(vue@3.4.31(typescript@5.4.2))':
     dependencies:
       '@floating-ui/dom': 1.6.7
       '@floating-ui/utils': 0.2.4
+      vue-demi: 0.14.8(vue@3.4.31(typescript@5.4.2))
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+
+  '@floating-ui/vue@1.1.5(vue@3.4.31(typescript@5.4.2))':
+    dependencies:
+      '@floating-ui/dom': 1.6.12
+      '@floating-ui/utils': 0.2.8
       vue-demi: 0.14.8(vue@3.4.31(typescript@5.4.2))
     transitivePeerDependencies:
       - '@vue/composition-api'
@@ -7196,7 +7224,11 @@ snapshots:
     dependencies:
       '@swc/helpers': 0.5.11
 
-  '@internationalized/number@3.5.3':
+  '@internationalized/date@3.6.0':
+    dependencies:
+      '@swc/helpers': 0.5.11
+
+  '@internationalized/number@3.6.0':
     dependencies:
       '@swc/helpers': 0.5.11
 
@@ -7630,11 +7662,11 @@ snapshots:
     dependencies:
       tslib: 2.6.3
 
-  '@tanstack/virtual-core@3.8.1': {}
+  '@tanstack/virtual-core@3.10.9': {}
 
-  '@tanstack/vue-virtual@3.8.1(vue@3.4.31(typescript@5.4.2))':
+  '@tanstack/vue-virtual@3.10.9(vue@3.4.31(typescript@5.4.2))':
     dependencies:
-      '@tanstack/virtual-core': 3.8.1
+      '@tanstack/virtual-core': 3.10.9
       vue: 3.4.31(typescript@5.4.2)
 
   '@testing-library/dom@10.4.0':
@@ -7776,10 +7808,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.5.0(@typescript-eslint/parser@8.5.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.4.2))(eslint@9.10.0(jiti@1.21.6))(typescript@5.4.2)':
+  '@typescript-eslint/eslint-plugin@8.5.0(@typescript-eslint/parser@8.5.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.3.3))(eslint@9.10.0(jiti@1.21.6))(typescript@5.4.2)':
     dependencies:
       '@eslint-community/regexpp': 4.11.0
-      '@typescript-eslint/parser': 8.5.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.4.2)
+      '@typescript-eslint/parser': 8.5.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.3.3)
       '@typescript-eslint/scope-manager': 8.5.0
       '@typescript-eslint/type-utils': 8.5.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.4.2)
       '@typescript-eslint/utils': 8.5.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.4.2)
@@ -8015,7 +8047,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/eslint-plugin@1.1.0(@typescript-eslint/utils@8.5.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.3.3))(eslint@9.10.0(jiti@1.21.6))(typescript@5.3.3)(vitest@2.1.1(@types/node@20.14.9))':
+  '@vitest/eslint-plugin@1.1.0(@typescript-eslint/utils@8.5.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.3.3))(eslint@9.10.0(jiti@1.21.6))(typescript@5.3.3)(vitest@2.1.1(@types/node@20.14.9)(jsdom@25.0.1))':
     dependencies:
       eslint: 9.10.0(jiti@1.21.6)
     optionalDependencies:
@@ -8023,7 +8055,7 @@ snapshots:
       typescript: 5.3.3
       vitest: 2.1.1(@types/node@20.14.9)(jsdom@25.0.1)
 
-  '@vitest/eslint-plugin@1.1.0(@typescript-eslint/utils@8.5.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.4.2))(eslint@9.10.0(jiti@1.21.6))(typescript@5.4.2)(vitest@2.1.1(@types/node@20.14.9))':
+  '@vitest/eslint-plugin@1.1.0(@typescript-eslint/utils@8.5.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.4.2))(eslint@9.10.0(jiti@1.21.6))(typescript@5.4.2)(vitest@2.1.1(@types/node@20.14.9)(jsdom@25.0.1))':
     dependencies:
       eslint: 9.10.0(jiti@1.21.6)
     optionalDependencies:
@@ -9614,12 +9646,6 @@ snapshots:
       eslint: 9.10.0(jiti@1.21.6)
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.5.0(@typescript-eslint/parser@8.5.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.3.3))(eslint@9.10.0(jiti@1.21.6))(typescript@5.3.3)
-
-  eslint-plugin-unused-imports@4.1.3(@typescript-eslint/eslint-plugin@8.5.0(@typescript-eslint/parser@8.5.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.4.2))(eslint@9.10.0(jiti@1.21.6))(typescript@5.4.2))(eslint@9.10.0(jiti@1.21.6)):
-    dependencies:
-      eslint: 9.10.0(jiti@1.21.6)
-    optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.5.0(@typescript-eslint/parser@8.5.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.4.2))(eslint@9.10.0(jiti@1.21.6))(typescript@5.4.2)
 
   eslint-plugin-vue@9.27.0(eslint@9.10.0(jiti@1.21.6)):
     dependencies:


### PR DESCRIPTION
Found a better replacement for `fast-deep-equal` here

https://github.com/SukkaW/eslint-config-sukka/blob/master/packages/shared/src/restricted-import.ts#L5

Also, is there any reason not to update the dependencies?