### PR TITLE
feat(NavigationMenu): expose item position to MenuContent

### DIFF
--- a/docs/content/docs/components/navigation-menu.md
+++ b/docs/content/docs/components/navigation-menu.md
@@ -179,6 +179,19 @@ Contains the content associated with each trigger.
   ]"
 />
 
+<CssVariablesTable
+  :data="[
+    {
+      cssVariable: '--reka-tabs-navigation-menu-content-size',
+      description: 'The size of the item.',
+    },
+    {
+      cssVariable: '--reka-tabs-navigation-menu-content-position',
+      description: 'The position of the item',
+    },
+  ]"
+/>
+
 ### Link
 
 A navigational link.


### PR DESCRIPTION
Similar to https://github.com/unovue/radix-vue/pull/1481 where I'd like to have the item position and size exposed, I'd like to have it available for `Content`.

This allows to position the content overlay underneath the active item, rather than only relative to the overall component.

Example

<img width="743" alt="Screenshot 2024-12-05 at 19 01 17" src="https://github.com/user-attachments/assets/8b7bd233-4ccc-4703-8abb-5340ac03be9f">

If you find this useful, I could also add an example story?
