### PR TITLE
fix: pass reference prop to PopperContent

### DIFF
--- a/packages/core/src/Menu/MenuContentImpl.vue
+++ b/packages/core/src/Menu/MenuContentImpl.vue
@@ -318,6 +318,7 @@ provideMenuContentContext({
           :position-strategy="positionStrategy"
           :sticky="sticky"
           :hide-when-detached="hideWhenDetached"
+          :reference="reference"
           @keydown="handleKeyDown"
           @blur="handleBlur"
           @pointermove="handlePointerMove"


### PR DESCRIPTION
<!---☝️ PR title should follow conventional commits (https://conventionalcommits.org) -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This PR adds the `reference` prop in `PopperContent` from `MenuContentImpl` to follow the documentation guidelines (at least for [DropdownMenu](https://reka-ui.com/docs/components/dropdown-menu#content) and [ContextMenu](https://reka-ui.com/docs/components/dropdown-menu#content)) where you can add `:reference` in the `Content` Component to replace the trigger. 

This enables the functionality to add custom locations for both Components. 

### 📸 Screenshots (if appropriate)

<!-- Add screenshots to help explain the change. -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.