### PR TITLE
feat(Editable): update model value only on submit

### DIFF
--- a/docs/content/components/editable.md
+++ b/docs/content/components/editable.md
@@ -150,33 +150,20 @@ Contains the cancel trigger of the editable component.
 
 ### Change only on submit
 
-Use the `default-value` prop to define starting value and `@submit` emit to handle the submit event.
-This is useful when you want to change the value only when the user submits the changes and have `auto-resize` working properly.
+By default the component will submit when `blur` event triggers. We can modify the `submit-mode` prop to alter this behavior.
+In this case, we want to submit only when user click on `EditableSubmitTrigger`, so we change the submit mode to `none`.
 
-```vue line=12-13
-<script setup lang="ts">
-const defaultValue = ref('Default value')
-
-function handleSubmit(label?: string) {
-  defaultValue.value = label
-}
-</script>
-
+```vue line=2,8
 <template>
-  <template>
-    <EditableRoot
-      :default-value="defaultValue"
-      @submit="handleSubmit"
-    >
-      <EditableArea>
-        <EditablePreview />
-        <EditableInput />
-      </EditableArea>
-      <EditableEditTrigger />
-      <EditableSubmitTrigger />
-      <EditableCancelTrigger />
-    </EditableRoot>
-  </template>
+  <EditableRoot submit-mode="none">
+    <EditableArea>
+      <EditablePreview />
+      <EditableInput />
+    </EditableArea>
+    <EditableEditTrigger />
+    <EditableSubmitTrigger />
+    <EditableCancelTrigger />
+  </EditableRoot>
 </template>
 ```
 

--- a/docs/content/components/editable.md
+++ b/docs/content/components/editable.md
@@ -146,6 +146,40 @@ Contains the cancel trigger of the editable component.
 
 <!-- @include: @/meta/EditableCancelTrigger.md -->
 
+## Examples
+
+### Change only on submit
+
+Use the `default-value` prop to define starting value and `@submit` emit to handle the submit event.
+This is useful when you want to change the value only when the user submits the changes and have `auto-resize` working properly.
+
+```vue line=12-13
+<script setup lang="ts">
+const defaultValue = ref('Default value')
+
+function handleSubmit(label?: string) {
+  defaultValue.value = label
+}
+</script>
+
+<template>
+  <template>
+    <EditableRoot
+      :default-value="defaultValue"
+      @submit="handleSubmit"
+    >
+      <EditableArea>
+        <EditablePreview />
+        <EditableInput />
+      </EditableArea>
+      <EditableEditTrigger />
+      <EditableSubmitTrigger />
+      <EditableCancelTrigger />
+    </EditableRoot>
+  </template>
+</template>
+```
+
 ## Accessibility
 
 ### Keyboard Interactions

--- a/packages/radix-vue/src/Editable/Editable.test.ts
+++ b/packages/radix-vue/src/Editable/Editable.test.ts
@@ -83,7 +83,7 @@ describe('editable', () => {
   })
 
   it('submits the value when pressing enter', async () => {
-    const { input, preview, rerender } = setup({ editableProps: { modelValue: '' }, emits: { 'onUpdate:modelValue': (data: string) => rerender({ modelValue: data }) } })
+    const { input, preview, rerender } = setup({ editableProps: { modelValue: '', submitMode: 'enter' }, emits: { 'onUpdate:modelValue': (data: string) => rerender({ modelValue: data }) } })
 
     await userEvent.type(input, 'New Value')
     await userEvent.keyboard(kbd.ENTER)

--- a/packages/radix-vue/src/Editable/Editable.test.ts
+++ b/packages/radix-vue/src/Editable/Editable.test.ts
@@ -94,8 +94,10 @@ describe('editable', () => {
   it('submits the value on blur', async () => {
     const { input, preview, rerender } = setup({ editableProps: { modelValue: '', submitMode: 'blur' }, emits: { 'onUpdate:modelValue': (data: string) => rerender({ modelValue: data, submitMode: 'blur' }) } })
 
+    await userEvent.dblClick(preview)
     await userEvent.type(input, 'New Value')
-    await userEvent.tab()
+    await userEvent.click(document.children[0])
+
     expect(preview).toBeVisible()
     expect(preview).toHaveTextContent('New Value')
   })
@@ -112,8 +114,10 @@ describe('editable', () => {
   it('submits the value on blur if submitMode is both', async () => {
     const { input, preview, rerender } = setup({ editableProps: { modelValue: '', submitMode: 'both' }, emits: { 'onUpdate:modelValue': (data: string) => rerender({ modelValue: data, submitMode: 'blur' }) } })
 
+    await userEvent.dblClick(preview)
     await userEvent.type(input, 'New Value')
-    await userEvent.tab()
+    await userEvent.click(document.children[0])
+
     expect(preview).toBeVisible()
     expect(preview).toHaveTextContent('New Value')
   })

--- a/packages/radix-vue/src/Editable/EditableInput.vue
+++ b/packages/radix-vue/src/Editable/EditableInput.vue
@@ -53,7 +53,7 @@ function handleSubmitKeyDown(event: KeyboardEvent) {
   <Primitive
     ref="primitiveElement"
     v-bind="props"
-    :value="context.modelValue.value"
+    :value="context.inputValue.value"
     :placeholder="placeholder"
     :disabled="disabled"
     :maxlength="context.maxLength.value"
@@ -63,7 +63,7 @@ function handleSubmitKeyDown(event: KeyboardEvent) {
     aria-label="editable input"
     :hidden="context.autoResize.value ? undefined : !context.isEditing.value"
     :style="context.autoResize.value ? { all: 'unset', gridArea: '1 / 1 / auto / auto', visibility: !context.isEditing.value ? 'hidden' : undefined } : undefined"
-    @input="context.modelValue.value = $event.target.value"
+    @input="context.inputValue.value = $event.target.value"
     @keydown.enter.space="handleSubmitKeyDown"
     @keydown.esc="context.cancel"
   >

--- a/packages/radix-vue/src/Editable/EditableRoot.vue
+++ b/packages/radix-vue/src/Editable/EditableRoot.vue
@@ -13,6 +13,7 @@ type EditableRootContext = {
   maxLength: Ref<number | undefined>
   disabled: Ref<boolean>
   modelValue: Ref<string | undefined>
+  inputValue: Ref<string | undefined>
   placeholder: Ref<{ edit: string, preview: string }>
   isEditing: Ref<boolean>
   submitMode: Ref<SubmitMode>
@@ -75,7 +76,7 @@ export const [injectEditableRootContext, provideEditableRootContext]
 </script>
 
 <script setup lang="ts">
-import { type Ref, computed, ref, toRefs } from 'vue'
+import { type Ref, computed, ref, toRefs, watch } from 'vue'
 import { Primitive, usePrimitiveElement } from '@/Primitive'
 import { useVModel } from '@vueuse/core'
 
@@ -146,21 +147,26 @@ const placeholder = computed(() => {
   return typeof propPlaceholder.value === 'string' ? { edit: propPlaceholder.value, preview: propPlaceholder.value } : propPlaceholder.value
 })
 
-const previousValue = ref(modelValue.value)
+const inputValue = ref(modelValue.value)
+
+watch(() => modelValue.value, () => {
+  inputValue.value = modelValue.value
+}, { immediate: true, deep: true })
 
 function cancel() {
-  modelValue.value = previousValue.value
   isEditing.value = false
   emits('update:state', 'cancel')
 }
 
 function edit() {
   isEditing.value = true
+  inputValue.value = modelValue.value
+
   emits('update:state', 'edit')
 }
 
 function submit() {
-  previousValue.value = modelValue.value
+  modelValue.value = inputValue.value
   isEditing.value = false
 
   emits('update:state', 'submit')
@@ -196,6 +202,7 @@ provideEditableRootContext({
   isEditing,
   maxLength,
   modelValue,
+  inputValue,
   placeholder,
   edit,
   cancel,


### PR DESCRIPTION
I have faced some issues with understanding how to make a field editable and not change `v-model` when editing and found this example in the Histoire files of the project, I think that this would be useful for others 😉