### PR TITLE
feat(Teleport): support Vue teleport defer prop

### DIFF
--- a/packages/radix-vue/src/Teleport/Teleport.vue
+++ b/packages/radix-vue/src/Teleport/Teleport.vue
@@ -13,6 +13,13 @@ export interface TeleportProps {
    */
   disabled?: boolean
   /**
+   * Defer the resolving of a Teleport target until other parts of the
+   * application have mounted (requires Vue 3.5.0+)
+   *
+   * {@link https://vuejs.org/guide/built-ins/teleport.html#deferred-teleport}
+   */
+  defer?: boolean
+  /**
    * Used to force mounting when more control is needed. Useful when
    * controlling animation with Vue animation libraries.
    */
@@ -35,6 +42,7 @@ const isMounted = useMounted()
     v-if="isMounted || forceMount"
     :to="to"
     :disabled="disabled"
+    :defer="defer"
   >
     <slot />
   </Teleport>


### PR DESCRIPTION
Vue 3.5 added a deffered prop to the built in `<teleport>` component which allows you to defer the teleport until the end of the current render cycle.

This PR exposes it on the Radix-Vue `Teleport` component but I'm not sure if we need to bump the Vue dependency for the project to be 3.5 as well 🤔 