### PR TITLE
Fix screen readers announcing toasts

### DIFF
--- a/packages/radix-vue/src/Toast/ToastRootImpl.vue
+++ b/packages/radix-vue/src/Toast/ToastRootImpl.vue
@@ -170,9 +170,9 @@ provideToastRootContext({ onClose: handleClose })
 <template>
   <ToastAnnounce
     v-if="announceTextContent"
-    role="status"
+    role="alert"
     :aria-live="type === 'foreground' ? 'assertive' : 'polite'"
-    aria-atomic
+    aria-atomic="true"
   >
     {{ announceTextContent }}
   </ToastAnnounce>
@@ -183,9 +183,9 @@ provideToastRootContext({ onClose: handleClose })
   >
     <Primitive
       :ref="forwardRef"
-      role="status"
+      role="alert"
       aria-live="off"
-      aria-atomic
+      aria-atomic="true"
       tabindex="0"
       data-radix-vue-collection-item
       v-bind="$attrs"


### PR DESCRIPTION
I'm currently fixing accessibility for our app and migrating to Radix. I struggled to make screen readers announce toasts and I think I found the culprit.

`aria-atomic` attribute specifically needs the `true` value to be read by screen readers, and VoiceOver requires the `role` to be set as `alert` for some reason.

Also, `announceTextContent` seems to display content as an array which is weird when it's announced:

VoiceOver:
<img width="646" alt="VoiceOver" src="https://github.com/user-attachments/assets/ceb12396-69ac-4a99-b74c-23be146c2846" />

NVDA:

<img width="185" alt="NVDA" src="https://github.com/user-attachments/assets/89a0f143-e8a4-48f4-9ded-3a740e85ee73" />

It's done on purpose (cf. https://github.com/unovue/radix-vue/blob/main/packages/radix-vue/src/Toast/utils.ts#L77-L78) but VoiceOver actually reads `"3"` as `three inches` for instance, because in our case we have a `strong` element on the number but there's no reason to make a pause between those words.

Setup: 
* NVDA + Firefox + Windows
* VoiceOver + Safari + MacOS

Also I couldn't make screen readers read the `label` prop from the `ToastViewport` component, I'm not sure if it's expected.

In conclusion the proposed fix makes the component work at least in my tests, even if there's still room for improvement IMO.

Let me know what you think!