### PR TITLE
fix(PinInput): error throw from resetPlaceholder's nextTick if component not in the DOM anymore

### DIFF
--- a/packages/radix-vue/src/PinInput/PinInputInput.vue
+++ b/packages/radix-vue/src/PinInput/PinInputInput.vue
@@ -52,7 +52,7 @@ function handleInput(event: InputEvent) {
 function resetPlaceholder() {
   const target = currentElement.value as HTMLInputElement
   nextTick(() => {
-    if (!target.value)
+    if (target && !target.value)
       target.placeholder = context.placeholder.value
   })
 }


### PR DESCRIPTION
This resolves the issue I discovered here: https://github.com/unovue/radix-vue/issues/1605
I have a reproduction example app (https://stackblitz.com/edit/bhw6xwfr-hcdmactw?file=src%2FApp.vue,package.json) but I failed to reproduce it in the unit tests :(