### PR TITLE
fix(DatePicker): error when unselecting a date

### DIFF
--- a/packages/radix-vue/src/DateField/DateFieldRoot.vue
+++ b/packages/radix-vue/src/DateField/DateFieldRoot.vue
@@ -192,7 +192,7 @@ watch(locale, (value) => {
 })
 
 watch(modelValue, (_modelValue) => {
-  if (!isNullish(_modelValue) || placeholder.value.compare(_modelValue) !== 0) {
+  if (!isNullish(_modelValue) && placeholder.value.compare(_modelValue) !== 0) {
     placeholder.value = _modelValue.copy()
   }
 })

--- a/packages/radix-vue/src/DatePicker/DatePicker.test.ts
+++ b/packages/radix-vue/src/DatePicker/DatePicker.test.ts
@@ -236,4 +236,17 @@ describe('datePicker', async () => {
     expect(month).not.toHaveAttribute('tabindex')
     expect(year).not.toHaveAttribute('tabindex')
   })
+
+  it('should select and deselect a date', async () => {
+    const { user, trigger, getByTestId } = setup()
+
+    await user.click(trigger)
+    const calendar = getByTestId('calendar')
+    const targetCell = calendar.querySelector('div[data-reka-calendar-cell-trigger]:not([data-outside-view])')!
+
+    await user.click(targetCell)
+    expect(calendar.querySelector('[data-selected]')).toBeInTheDocument()
+    await user.click(targetCell)
+    expect(calendar.querySelector('[data-selected]')).not.toBeInTheDocument()
+  })
 })

--- a/packages/radix-vue/src/DatePicker/DatePicker.test.ts
+++ b/packages/radix-vue/src/DatePicker/DatePicker.test.ts
@@ -242,7 +242,7 @@ describe('datePicker', async () => {
 
     await user.click(trigger)
     const calendar = getByTestId('calendar')
-    const targetCell = calendar.querySelector('div[data-reka-calendar-cell-trigger]:not([data-outside-view])')!
+    const targetCell = calendar.querySelector('div[data-radix-vue-calendar-cell-trigger]:not([data-outside-view])')!
 
     await user.click(targetCell)
     expect(calendar.querySelector('[data-selected]')).toBeInTheDocument()


### PR DESCRIPTION
This resolves https://github.com/unovue/radix-vue/issues/1618.

Again, I failed to reproduce the issue in unit tests. I tried this, unsuccessfully:

```ts
  it('does not throw when selecting the same date twice', async () => {
    const { user, trigger, getByTestId, rerender } = setup({
      datePickerProps: { modelValue: calendarDate },
      emits: { 'onUpdate:modelValue': (data: DateValue) => rerender({ modelValue: data }) },
    })

    await user.click(trigger)
    const selectedDay = getByTestId('calendar').querySelector<HTMLElement>('[data-selected]')!
    await user.click(selectedDay)
  })
```