### PR TITLE
fix: focus scope trap

### DIFF
--- a/packages/core/src/FocusScope/FocusScope.vue
+++ b/packages/core/src/FocusScope/FocusScope.vue
@@ -184,7 +184,7 @@ watchEffect(async (cleanupFn) => {
 })
 
 function handleKeyDown(event: KeyboardEvent) {
-  if (!props.loop && !props.trapped)
+  if (!props.loop || !props.trapped)
     return
   if (focusScope.paused)
     return


### PR DESCRIPTION
Currently, even when `modal` is set to `false` in the Popover component, focus remains trapped. This PR resolves the issue by ensuring focus behaves as expected when `modal` is disabled.