### PR TITLE
fix: remove type casting in useBodyScrollLock (radix-vue)

### DIFF
--- a/packages/radix-vue/src/shared/useBodyScrollLock.ts
+++ b/packages/radix-vue/src/shared/useBodyScrollLock.ts
@@ -119,9 +119,9 @@ function checkOverflowScroll(ele: Element): boolean {
     return true
   }
   else {
-    const parent = ele.parentNode as Element
+    const parent = ele.parentNode
 
-    if (!parent || parent.tagName === 'BODY')
+    if (!(parent instanceof Element) || parent.tagName === 'BODY')
       return false
 
     return checkOverflowScroll(parent)


### PR DESCRIPTION
Follow-up to  #1462, which was not comprehensive solution enough to fix occuring type errors.